### PR TITLE
Use Nix Environment Selector plugin to use nix

### DIFF
--- a/app/.vscode/extensions.json
+++ b/app/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "arrterian.nix-env-selector",
+        "bbenoist.nix",
+        "jnoortheen.nix-ide"
+    ]
+}

--- a/app/.vscode/settings.json
+++ b/app/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "nixEnvSelector.nixFile": "${workspaceRoot}/shell.nix",
+    "rust-analyzer.linkedProjects": [
+        "./Cargo.toml",
+    ]
+}


### PR DESCRIPTION
Use the development environment defined in shell.nix.