### PR TITLE
Improve developer experience

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -12,7 +12,7 @@ tailwind-watch:
 build:
   npm install
   just tailwind
-  cargo build
+  cargo build --target=wasm32-unknown-unknown
   trunk build
 
 build-release:

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A development environment and build system for mina-block-explorer";
+  description = "A development environment and build system for the mina-block-explorer project";
 
   inputs = {
     nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
@@ -32,6 +32,7 @@
             nodejs_18
             openssl
             pkg-config
+            rsync
             trunk
             (rust-bin.selectLatestNightlyWith( toolchain: toolchain.default.override {
               extensions= [ "rust-src" "rust-analyzer" ];

--- a/package.json
+++ b/package.json
@@ -1,12 +1,7 @@
 {
+  "private": true,
   "name": "mina-block-explorer-dev",
-  "version": "0.1.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {},
-  "keywords": [],
-  "author": "",
-  "license": "MPLv2",
   "devDependencies": {
     "@tailwindcss/container-queries": "^0.1.1",
     "cypress": "^13.6.1",


### PR DESCRIPTION
- Modify the cargo build to use the same arguments as the trunk build so it reuses the build artifacts.

- Include rsync in nix flakes

- Cleaned up package.json to be private and remove unnecessary arguments

Fixes: https://github.com/Granola-Team/mina-block-explorer/issues/109, https://github.com/Granola-Team/mina-block-explorer/issues/111, https://github.com/Granola-Team/mina-block-explorer/issues/112