### PR TITLE
Improve Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -20,19 +20,25 @@ build-release:
   just tailwind
   cargo build --release
 
-clean:
+clean: kill-server
   rm -rf dist
   trunk clean
   cargo clean
+  rm -f assets/css/styles.css
+  rm -fr cypress/screenshots/
+  rm -fr cypress/snapshots/navigation/desktop-menu-look-and-feel.cy.js/__diff_output__/
+  rm -fr cypress/snapshots/navigation/mobile-menu-look-and-feel.cy.js/__diff_output__/
+  rm -fr node_modules/
+  rm -f package-lock.json
 
-test: test-unit
+test: test-unit test-e2e
 
 kill-server:
-  kill $(cat .pid 2>/dev/null) 2>/dev/null || true
+  if [ -e .pid ]; then kill "$(cat .pid)" && rm .pid ; fi
 
 test-e2e: && kill-server
   trunk serve --port=5274 & pid=$!; echo "$pid" > .pid
-  sleep 5
+  sleep 10  # Wait for trunk server to start
   npx cypress run -r list -q
   
 test-unit: build

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,7 +3,6 @@ const { addMatchImageSnapshotPlugin } = require("@simonsmith/cypress-image-snaps
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:5274',
     setupNodeEvents(on, config) {
       addMatchImageSnapshotPlugin(on)
     },

--- a/ops/buildkite-pipeline.yaml
+++ b/ops/buildkite-pipeline.yaml
@@ -11,6 +11,6 @@ steps:
   env: 
     CYPRESS_failOnSnapshotDiff: "false"
   command: |
-    nix-shell shell.nix --run "just --justfile Justfile test-ci"
+    nix-shell shell.nix --run "just --justfile Justfile test"
   key: build
   depends_on: prereqs


### PR DESCRIPTION
Fixes #217 
... does better cleanup of files and resources (processes).
... the "test" target actually runs all tests, as expected.
... enables concurrent testing on CI, which is otherwise broken due to clashing on the Cypress port.