### PR TITLE
(table) fix labeling when less than 10 row items

### DIFF
--- a/src/common/table.rs
+++ b/src/common/table.rs
@@ -78,7 +78,7 @@ where
                             {format!(
                                 "Showing {} to {} of {} records",
                                 pg.start_index(),
-                                pg.end_index(),
+                                std::cmp::min(pg.end_index(), pg.total_records),
                                 pg.total_records,
                             )}
 


### PR DESCRIPTION
Fixes:
* https://github.com/Granola-Team/mina-block-explorer/issues/281