### PR TITLE
Make account dialog spotlight occupy the full width of the available dialog

### DIFF
--- a/src/account_dialog/dialog.rs
+++ b/src/account_dialog/dialog.rs
@@ -53,7 +53,7 @@ pub fn AccountDialogView() -> impl IntoView {
         >
             <dialog
                 id="accountdialog"
-                class="z-20 w-full max-w-3xl h-screen fixed top-0 mr-0 ml-auto flex flex-col items-stretch p-4 bg-background"
+                class="z-20 w-full max-w-3xl h-screen fixed top-0 mr-0 ml-auto flex flex-col items-stretch bg-background"
             >
                 <button id="closedialog" class="absolute top-0 right-0 p-12 z-30">
                     <a href=base.get()>X</a>

--- a/src/common/spotlight.rs
+++ b/src/common/spotlight.rs
@@ -20,7 +20,7 @@ pub fn SpotlightSection(
     view! {
         <section
             id="spotlight-section"
-            class="@container md:col-start-2 md:col-end-3 md:rounded-lg bg-table-section p-0 md:p-4 mb-2"
+            class="@container md:col-start-2 md:col-end-3 md:rounded-lg bg-table-section p-0 p-4 mb-2"
         >
             <h1 class="md:rounded-lg h-16 pl-8 text-xl bg-table-section flex justify-start items-center">
                 {header}
@@ -71,7 +71,7 @@ fn Spotlight(
 
             </div>
         </div>
-        <table class="font-mono @3xl:mx-[10rem] bg-white rounded-xl mt-8 p-4 table-fixed flex flex-wrap">
+        <table class="font-mono @3xl:mx-[10rem] bg-white rounded-xl mt-8 md:p-4 table-fixed flex flex-wrap">
             {spotlight_items
                 .into_iter()
                 .map(|entry| {


### PR DESCRIPTION
Closes #312 
<img width="386" alt="Screen Shot 2024-03-06 at 11 09 04 AM" src="https://github.com/Granola-Team/mina-block-explorer/assets/19426804/91e94a4e-5045-42e4-b45a-4e7eb7449ddc">
