### PR TITLE
make text smaller, and left column less wide, on mobile

### DIFF
--- a/src/common/functions.rs
+++ b/src/common/functions.rs
@@ -143,7 +143,7 @@ pub fn wrap_in_pill(
     any: HtmlElement<html::AnyElement>,
     pill_variant: PillVariant,
 ) -> HtmlElement<html::AnyElement> {
-    let value_class_str_base = "text-white p-0.5 text-sm flex justify-center items-center w-fit";
+    let value_class_str_base = "text-white p-0.5 flex justify-center items-center w-fit";
     let pill_class_str_base = format!("{} {}", value_class_str_base, "px-2 rounded-full");
 
     let pill_class_str = format!(

--- a/src/common/spotlight.rs
+++ b/src/common/spotlight.rs
@@ -96,7 +96,8 @@ fn Spotlight(
 
 #[component]
 fn SpotlightRow(entry: SpotlightEntry) -> impl IntoView {
-    let th_td_class_base = "flex justify-start items-center m-1 p-1 text-left text-xs md:text-sm whitespace-nowrap";
+    let th_td_class_base =
+        "flex justify-start items-center m-1 p-1 text-left text-xs md:text-sm whitespace-nowrap";
 
     view! {
         <th class=format!(

--- a/src/common/spotlight.rs
+++ b/src/common/spotlight.rs
@@ -1,6 +1,5 @@
 use crate::common::{components::*, functions::*};
 use leptos::*;
-use web_sys::js_sys::Array;
 
 #[derive(Default)]
 pub struct SpotlightEntry {

--- a/src/common/spotlight.rs
+++ b/src/common/spotlight.rs
@@ -96,26 +96,21 @@ fn Spotlight(
 
 #[component]
 fn SpotlightRow(entry: SpotlightEntry) -> impl IntoView {
-    let th_td_class_base = "flex justify-start items-center m-1 p-1 text-left";
+    let th_td_class_base = "flex justify-start items-center m-1 p-1 text-left text-xs md:text-sm whitespace-nowrap";
 
     view! {
         <th class=format!(
             "{} {}",
             th_td_class_base,
-            "w-40 min-w-40 text-sm font-normal text-slate-400 whitespace-nowrap",
+            "w-36 md:w-40 min-w-36 md:min-w-40 font-normal text-slate-400",
         )>{entry.label} :</th>
         <td class=format!(
             "{} {}",
             th_td_class_base,
-            "block w-fit text-ellipsis overflow-hidden whitespace-nowrap",
+            "block w-fit text-ellipsis overflow-hidden",
         )>
             {match entry.any_el {
                 Some(any_el) => {
-                    let class_list_array = Array::new();
-                    class_list_array.push(&"text-sm".into());
-                    class_list_array.push(&"text-ellipsis".into());
-                    class_list_array.push(&"overflow-hidden".into());
-                    any_el.class_list().add(&class_list_array).unwrap();
                     match entry.copiable {
                         true => view! { <CopyToClipboard>{any_el}</CopyToClipboard> }.into_view(),
                         false => any_el.into_view(),


### PR DESCRIPTION
Closes #311 
<img width="386" alt="Screen Shot 2024-03-06 at 1 59 47 PM" src="https://github.com/Granola-Team/mina-block-explorer/assets/19426804/401ab46b-9212-4dae-81f7-6dce9d0ae66e">
