### PR TITLE
Make `coinbase` a green "pill" in the blocks tables

### DIFF
--- a/src/addresses/functions.rs
+++ b/src/addresses/functions.rs
@@ -89,7 +89,7 @@ pub fn get_spotlight_data(account: &AccountSummary) -> Vec<SpotlightEntry> {
             label: String::from("Nonce"),
             any_el: Some(convert_to_pill(
                 account.nonce.to_string(),
-                PillVariant::Blue,
+                PillVariant::Grey,
             )),
             ..Default::default()
         },

--- a/src/blocks/table_traits.rs
+++ b/src/blocks/table_traits.rs
@@ -52,7 +52,10 @@ impl TableData for Vec<Option<BlocksQueryBlocks>> {
                         get_creator_account(block),
                         format!("/blocks/accounts/{}", get_creator_account(block)),
                     ),
-                    wrap_in_pill(decorate_with_currency_tag(get_coinbase(block), "mina".to_string()),PillVariant::Green),
+                    wrap_in_pill(
+                        decorate_with_currency_tag(get_coinbase(block), "mina".to_string()),
+                        PillVariant::Green,
+                    ),
                     convert_to_pill(
                         get_transaction_count(block).map_or_else(String::new, |o| o.to_string()),
                         PillVariant::Blue,

--- a/src/blocks/table_traits.rs
+++ b/src/blocks/table_traits.rs
@@ -160,7 +160,10 @@ impl TableData for SummaryPageBlocksQueryBlocks {
                         get_creator_account(block),
                         format!("/summary/accounts/{}", get_creator_account(block)),
                     ),
-                    decorate_with_currency_tag(get_coinbase(block), "mina".to_string()),
+                    wrap_in_pill(
+                        decorate_with_currency_tag(get_coinbase(block), "mina".to_string()),
+                        PillVariant::Green,
+                    ),
                     convert_to_pill(
                         get_transaction_count(block).map_or_else(String::new, |o| o.to_string()),
                         PillVariant::Blue,

--- a/src/blocks/table_traits.rs
+++ b/src/blocks/table_traits.rs
@@ -41,7 +41,7 @@ impl TableData for Vec<Option<BlocksQueryBlocks>> {
                         get_state_hash(block),
                         format!("/blocks/{}/spotlight", get_state_hash(block)),
                     ),
-                    convert_to_pill(get_slot(block), PillVariant::Orange),
+                    convert_to_pill(get_slot(block), PillVariant::Grey),
                     convert_array_to_span(vec![
                         convert_to_span(print_time_since(&get_date_time(block))),
                         convert_to_span(get_date_time(block))
@@ -55,7 +55,7 @@ impl TableData for Vec<Option<BlocksQueryBlocks>> {
                     wrap_in_pill(decorate_with_currency_tag(get_coinbase(block), "mina".to_string()),PillVariant::Green),
                     convert_to_pill(
                         get_transaction_count(block).map_or_else(String::new, |o| o.to_string()),
-                        PillVariant::Green,
+                        PillVariant::Blue,
                     ),
                     convert_to_pill(
                         get_snark_job_count(block).map_or_else(String::new, |o| o.to_string()),
@@ -114,7 +114,7 @@ impl TableData for Vec<Option<BlocksQueryBlocksTransactionsUserCommands>> {
                             get_user_command_amount(user_command),
                             "mina".to_string(),
                         ),
-                        PillVariant::Green,
+                        PillVariant::Blue,
                     ),
                 ],
                 None => vec![],
@@ -160,7 +160,7 @@ impl TableData for SummaryPageBlocksQueryBlocks {
                     decorate_with_currency_tag(get_coinbase(block), "mina".to_string()),
                     convert_to_pill(
                         get_transaction_count(block).map_or_else(String::new, |o| o.to_string()),
-                        PillVariant::Green,
+                        PillVariant::Blue,
                     ),
                     convert_to_pill(
                         get_snark_job_count(block).map_or_else(String::new, |o| o.to_string()),

--- a/src/blocks/table_traits.rs
+++ b/src/blocks/table_traits.rs
@@ -52,7 +52,7 @@ impl TableData for Vec<Option<BlocksQueryBlocks>> {
                         get_creator_account(block),
                         format!("/blocks/accounts/{}", get_creator_account(block)),
                     ),
-                    decorate_with_currency_tag(get_coinbase(block), "mina".to_string()),
+                    wrap_in_pill(decorate_with_currency_tag(get_coinbase(block), "mina".to_string()),PillVariant::Green),
                     convert_to_pill(
                         get_transaction_count(block).map_or_else(String::new, |o| o.to_string()),
                         PillVariant::Green,


### PR DESCRIPTION
Closes #309 

Also, standardize how pill colors are used:
* Grey: numeric info such as slots and heights
* Blue: counts
* Orange: fees
* Green: balances and transfers