### PR TITLE
Remove `height` column on SNARK Jobs tab at the block spotlight level.

### DIFF
--- a/cypress/e2e/table-columns/ordered-columns.cy.js
+++ b/cypress/e2e/table-columns/ordered-columns.cy.js
@@ -32,6 +32,18 @@ suite(["@CI"],'snarks table', () => {
 });
 
 
+suite(["@CI"],'block spotlight snarks table', () => {
+
+    let pages = ['/blocks/3NKLE73AnqCKVit9h3yEZsPbbJBmVfW5WWKA6pNsUjqh3Nm1mKSK/snark-jobs'];
+    let columns = ['State Hash', 'Age', 'Prover', 'Work Ids', 'Fee'];
+
+    pages.forEach(page => it(`on ${page} includes correct columns`, () => {
+        cy.visit(page);
+        cy.tableHasOrderedColumns('SNARK Jobs', columns);
+    }));
+});
+
+
 suite(["@CI"],'internal commands table', () => {
 
     let pages = ['/blocks/3NKyujsdi2GtWA1XC9KJ6nvXeLAd3DNvYrm1PUGEagj9899s1LMz/internal-commands'];

--- a/src/blocks/functions.rs
+++ b/src/blocks/functions.rs
@@ -10,11 +10,6 @@ use crate::common::{
 };
 use graphql_client::reqwest::post_graphql;
 
-pub fn get_snark_block_height(snark: &BlocksQueryBlocksSnarkJobs) -> String {
-    snark
-        .block_height
-        .map_or_else(String::new, |o| o.to_string())
-}
 pub fn get_snark_block_state_hash(snark: &BlocksQueryBlocksSnarkJobs) -> String {
     snark
         .block_state_hash

--- a/src/blocks/table_traits.rs
+++ b/src/blocks/table_traits.rs
@@ -179,7 +179,7 @@ impl TableData for SummaryPageBlocksQueryBlocks {
 
 impl TableData for Vec<Option<BlocksQueryBlocksSnarkJobs>> {
     fn get_columns(&self) -> Vec<String> {
-        ["Height", "State Hash", "Age", "Prover", "Work Ids", "Fee"]
+        ["State Hash", "Age", "Prover", "Work Ids", "Fee"]
             .iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>()
@@ -189,7 +189,6 @@ impl TableData for Vec<Option<BlocksQueryBlocksSnarkJobs>> {
         self.iter()
             .map(|opt_snark| match opt_snark {
                 Some(snark) => vec![
-                    convert_to_span(get_snark_block_height(snark)),
                     convert_to_link(
                         get_snark_block_state_hash(snark),
                         format!("/blocks/{}", get_snark_block_state_hash(snark)),


### PR DESCRIPTION
Closes #354 