### PR TITLE
Remove table-fixed from <table/> to avoid squishing on mobile

### DIFF
--- a/src/common/table.rs
+++ b/src/common/table.rs
@@ -37,7 +37,7 @@ pub fn TableContainer(children: Children) -> impl IntoView {
 #[component]
 pub fn Table(children: Children) -> impl IntoView {
     view! {
-        <table class="font-mono table-fixed md:rounded-b-lg w-full @xs:w-[175%] @md:w-[150%] @2xl:w-[125%] @7xl:w-full">
+        <table class="font-mono md:rounded-b-lg w-full @xs:w-[175%] @md:w-[150%] @2xl:w-[125%] @7xl:w-full">
             {children()}
         </table>
     }


### PR DESCRIPTION
Closes #590 

This has the downside of "jumping" columns when the table data is loading since the columns are in "auto" layout mode, but the table is not usable on mobile otherwise.