### PR TITLE
remove workIds vestiges from the GraphQL queries

### DIFF
--- a/graphql/queries/account_dialog.graphql
+++ b/graphql/queries/account_dialog.graphql
@@ -1,5 +1,20 @@
-query AccountActivityQuery($blocks_query: BlockQueryInput!, $blocks_limit: Int = 3, $blocks_sort_by: BlockSortByInput!, $snarks_sort_by: SnarkSortByInput!, $snarks_limit: Int = 3, $snarks_query: SnarkQueryInput!, $trans_limit: Int = 10, $trans_sort_by: TransactionSortByInput!, $outgoing_trans_query: TransactionQueryInput!,$incoming_trans_query: TransactionQueryInput!) {
-  incoming_transactions: transactions(sortBy: $trans_sort_by, limit: $trans_limit, query: $incoming_trans_query) {
+query AccountActivityQuery(
+  $blocks_query: BlockQueryInput!
+  $blocks_limit: Int = 3
+  $blocks_sort_by: BlockSortByInput!
+  $snarks_sort_by: SnarkSortByInput!
+  $snarks_limit: Int = 3
+  $snarks_query: SnarkQueryInput!
+  $trans_limit: Int = 10
+  $trans_sort_by: TransactionSortByInput!
+  $outgoing_trans_query: TransactionQueryInput!
+  $incoming_trans_query: TransactionQueryInput!
+) {
+  incoming_transactions: transactions(
+    sortBy: $trans_sort_by
+    limit: $trans_limit
+    query: $incoming_trans_query
+  ) {
     canonical
     fee
     from
@@ -15,7 +30,11 @@ query AccountActivityQuery($blocks_query: BlockQueryInput!, $blocks_limit: Int =
     failureReason
     memo
   }
-  outgoing_transactions:transactions(sortBy: $trans_sort_by, limit: $trans_limit, query: $outgoing_trans_query) {
+  outgoing_transactions: transactions(
+    sortBy: $trans_sort_by
+    limit: $trans_limit
+    query: $outgoing_trans_query
+  ) {
     canonical
     fee
     from
@@ -40,7 +59,6 @@ query AccountActivityQuery($blocks_query: BlockQueryInput!, $blocks_limit: Int =
     fee
     dateTime
     prover
-    workIds
   }
   blocks(sortBy: $blocks_sort_by, limit: $blocks_limit, query: $blocks_query) {
     canonical

--- a/graphql/queries/snarks.graphql
+++ b/graphql/queries/snarks.graphql
@@ -1,10 +1,13 @@
-query SnarksQuery($sort_by: SnarkSortByInput!, $limit: Int = 10, $query: SnarkQueryInput!) {
-  snarks(sortBy: $sort_by, limit: $limit, query: $query ) {
+query SnarksQuery(
+  $sort_by: SnarkSortByInput!
+  $limit: Int = 10
+  $query: SnarkQueryInput!
+) {
+  snarks(sortBy: $sort_by, limit: $limit, query: $query) {
     blockHeight
     dateTime
     prover
     canonical
-    workIds
     block {
       stateHash
     }

--- a/src/snarks/graphql.rs
+++ b/src/snarks/graphql.rs
@@ -21,7 +21,6 @@ impl Default for snarks_query::SnarksQuerySnarks {
             block_height: None,
             date_time: None,
             prover: None,
-            work_ids: None,
             block: None,
             fee: None,
             canonical: None,


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-block-explorer/issues/601

* Remove workId reference from the codebase