### PR TITLE
Make GraphQL and REST endpoints configurable by env vars

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,11 @@
 use std::{env, fs};
 
 fn main() {
+    let graphql_url = env::var("GRAPHQL_URL").unwrap_or_else(|_| "https://graphql.minaexplorer.com".to_string());
+    let rest_url = env::var("REST_URL").unwrap_or_else(|_| "https://api.minaexplorer.com".to_string());
+    println!("cargo:rustc-env=GRAPHQL_URL={}", graphql_url);
+    println!("cargo:rustc-env=REST_URL={}", rest_url);
+
     let feature_flag_enabled = match env::var("BERKELEY_FEATURES_ENABLED") {
         Ok(value) => value == "true",
         Err(_) => false,

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,10 @@
 use std::{env, fs};
 
 fn main() {
-    let graphql_url = env::var("GRAPHQL_URL").unwrap_or_else(|_| "https://graphql.minaexplorer.com".to_string());
-    let rest_url = env::var("REST_URL").unwrap_or_else(|_| "https://api.minaexplorer.com".to_string());
+    let graphql_url =
+        env::var("GRAPHQL_URL").unwrap_or_else(|_| "https://graphql.minaexplorer.com".to_string());
+    let rest_url =
+        env::var("REST_URL").unwrap_or_else(|_| "https://api.minaexplorer.com".to_string());
     println!("cargo:rustc-env=GRAPHQL_URL={}", graphql_url);
     println!("cargo:rustc-env=REST_URL={}", rest_url);
 

--- a/src/common/constants.rs
+++ b/src/common/constants.rs
@@ -1,5 +1,5 @@
-pub const GRAPHQL_ENDPOINT: &str = "https://graphql.minaexplorer.com";
-pub const REST_ENDPOINT: &str = "https://api.minaexplorer.com";
+pub const GRAPHQL_ENDPOINT: &str = env!("GRAPHQL_URL");
+pub const REST_ENDPOINT: &str = env!("REST_URL");
 pub const TABLE_RECORD_SIZE: i64 = 100;
 pub const TABLE_DEFAULT_PAGE_SIZE: usize = 10;
 pub const ESTIMATED_ROW_HEIGHT: usize = 48;

--- a/src/summary/functions.rs
+++ b/src/summary/functions.rs
@@ -1,8 +1,8 @@
 use super::models::BlockchainSummary;
-use crate::common::models::*;
+use crate::common::{constants::REST_ENDPOINT, models::*};
 
 pub async fn load_data() -> Result<BlockchainSummary, MyError> {
-    let response = reqwest::get("https://api.minaexplorer.com/summary")
+    let response = reqwest::get(format!("{}/summary", REST_ENDPOINT))
         .await
         .map_err(|e| MyError::NetworkError(e.to_string()))?;
 


### PR DESCRIPTION
Fixes: https://github.com/Granola-Team/mina-block-explorer/issues/597

To change the GraphQL and REST URLs export the following variables
```
export GRAPHQL_URL=http://localhost:8080/graphql
export REST_URL=http://localhost:8080

nix develop --command just dev
```