### PR TITLE
Update summary model with staking ledger hash for page header

### DIFF
--- a/src/summary/models.rs
+++ b/src/summary/models.rs
@@ -3,10 +3,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockchainSummary {
-    pub blockchain_length: u64,
+    pub blockchain_length: u32,
     pub circulating_supply: String,
-    pub epoch: u16,
-    pub slot: u16,
+    pub epoch: u32,
+    pub slot: u32,
+    pub staking_epoch_ledger_hash: String,
     pub total_currency: String,
 }
 
@@ -37,6 +38,8 @@ mod float_tests {
             blockchain_length: 314394,
             epoch: 67,
             slot: 4194,
+            staking_epoch_ledger_hash: "jxKCrryFrvzBE4iUURcS9zNTKcRdejiE9K28Bqcu7Us7RQqNfdL"
+                .to_owned(),
             total_currency: "1105297372.840039233".to_owned(),
         };
         assert_eq!(bs.circ_supply(), 2345345.4312431243);


### PR DESCRIPTION
Also changes `u16`/`u64` -> `u32` to [match Indexer](https://github.com/Granola-Team/mina-indexer/blob/7865e798158f5bbb96c8a4cc30c250ce42ebf066/rust/src/web/rest/blockchain.rs#L21).

Resolves Granola-Team/mina-block-explorer#634

Unblocks #629