### PR TITLE
fix(CD): actually deploy to Prod

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -80,4 +80,4 @@ dev: build_npm
 
 publish: clean build_npm
   trunk build --release --filehash true
-  pnpm exec -- wrangler pages deploy
+  pnpm exec -- wrangler pages deploy --branch main


### PR DESCRIPTION
Relates to Granola-Team/mina-block-explorer#44 and Granola-Team/mina-block-explorer#700

Our Cloudflare Pages production deployment needs `--branch main`, but it doesn't matter the git branch you are on.