### PR TITLE
Disable all filter inputs on the account spotlight page

### DIFF
--- a/src/account_activity/components.rs
+++ b/src/account_activity/components.rs
@@ -232,6 +232,7 @@ pub fn AccountTransactionsSection(
         TableColumn {
             column: "Height".to_string(),
             is_searchable: true,
+            is_disabled: true,
             html_input_type: "number".to_string(),
             alignment: Some(ColumnTextAlignment::Right),
             width: Some(String::from(TABLE_COL_NUMERIC_WIDTH)),
@@ -240,6 +241,7 @@ pub fn AccountTransactionsSection(
         TableColumn {
             column: "Txn Hash".to_string(),
             is_searchable: true,
+            is_disabled: true,
             width: Some(String::from(TABLE_COL_HASH_WIDTH)),
             ..Default::default()
         },
@@ -267,6 +269,7 @@ pub fn AccountTransactionsSection(
         TableColumn {
             column: "Counterparty".to_string(),
             is_searchable: true,
+            is_disabled: true,
             width: Some(String::from(TABLE_COL_HASH_WIDTH)),
             ..Default::default()
         },
@@ -321,6 +324,7 @@ pub fn AccountInternalCommandsSection(
         TableColumn {
             column: "Height".to_string(),
             is_searchable: true,
+            is_disabled: true,
             html_input_type: "number".to_string(),
             alignment: Some(ColumnTextAlignment::Right),
             width: Some(String::from(TABLE_COL_NUMERIC_WIDTH)),
@@ -329,6 +333,7 @@ pub fn AccountInternalCommandsSection(
         TableColumn {
             column: "State Hash".to_string(),
             is_searchable: true,
+            is_disabled: true,
             width: Some(String::from(TABLE_COL_HASH_WIDTH)),
             ..Default::default()
         },
@@ -456,6 +461,7 @@ pub fn AccountOverviewSnarkJobTable(
         TableColumn {
             column: "Height".to_string(),
             is_searchable: true,
+            is_disabled: true,
             html_input_type: "number".to_string(),
             alignment: Some(ColumnTextAlignment::Right),
             width: Some(String::from(TABLE_COL_NUMERIC_WIDTH)),
@@ -464,6 +470,7 @@ pub fn AccountOverviewSnarkJobTable(
         TableColumn {
             column: "State Hash".to_string(),
             is_searchable: true,
+            is_disabled: true,
             width: Some(String::from(TABLE_COL_HASH_WIDTH)),
             ..Default::default()
         },
@@ -539,6 +546,7 @@ pub fn AccountOverviewBlocksTable(
         TableColumn {
             column: "Height".to_string(),
             is_searchable: true,
+            is_disabled: true,
             html_input_type: "number".to_string(),
             alignment: Some(ColumnTextAlignment::Right),
             width: Some(String::from(TABLE_COL_NUMERIC_WIDTH)),
@@ -547,12 +555,14 @@ pub fn AccountOverviewBlocksTable(
         TableColumn {
             column: "State Hash".to_string(),
             is_searchable: true,
+            is_disabled: true,
             width: Some(String::from(TABLE_COL_HASH_WIDTH)),
             ..Default::default()
         },
         TableColumn {
             column: "Slot".to_string(),
             is_searchable: true,
+            is_disabled: true,
             html_input_type: "number".to_string(),
             alignment: Some(ColumnTextAlignment::Right),
             width: Some(String::from(TABLE_COL_NUMERIC_WIDTH)),

--- a/src/accounts/page.rs
+++ b/src/accounts/page.rs
@@ -63,6 +63,7 @@ fn AccountsPageContents() -> impl IntoView {
             is_searchable: true,
             html_input_type: "number".to_string(),
             alignment: Some(ColumnTextAlignment::Right),
+            ..Default::default()
         },
         TableColumn {
             column: "Nonce".to_string(),

--- a/src/common/table.rs
+++ b/src/common/table.rs
@@ -34,6 +34,7 @@ pub enum ColumnTextAlignment {
 pub struct TableColumn {
     pub column: String,
     pub is_searchable: bool,
+    pub is_disabled: bool,
     pub sort_direction: Option<TableSortDirection>,
     pub width: Option<String>,
     pub html_input_type: String,
@@ -45,6 +46,7 @@ impl Default for TableColumn {
         TableColumn {
             column: String::new(),
             is_searchable: false,
+            is_disabled: false,
             sort_direction: None,
             width: None,
             html_input_type: "text".to_string(),
@@ -54,7 +56,7 @@ impl Default for TableColumn {
 }
 
 const INPUT_CLASS: &str =
-    " block w-full mt-1 h-7 text-base text-sm font-normal font-mono p-2 rounded ";
+    " block w-full mt-1 h-7 text-base text-sm font-normal font-mono p-2 rounded disabled:bg-white disabled:cursor-not-allowed ";
 const CELL_PADDING_CLASS: &str = " first:pl-8 pl-4 last:pr-4 ";
 
 #[component]
@@ -231,6 +233,7 @@ fn ColumnHeader(id: String, column: TableColumn) -> impl IntoView {
                             update_value();
                         }
 
+                        disabled=column.is_disabled
                         node_ref=input_element
                         class=INPUT_CLASS.to_string() + &input_class
                         id=id_copy


### PR DESCRIPTION
Prevents crashing.

Closes #980 