### PR TITLE
Add chart filters component to support filtering by various data points

### DIFF
--- a/cypress/e2e/analytics/filter.cy.js
+++ b/cypress/e2e/analytics/filter.cy.js
@@ -1,0 +1,18 @@
+suite(["@tier2"], "filters", () => {
+  let analytics_pages = [
+    {
+      page: "/analytics/snarks",
+      filters: [{ id: "block-limit", url_key: "limit", test_val: 100 }],
+    },
+  ];
+
+  analytics_pages.forEach(({ page, filters }) =>
+    it(`has URL integrated filters ${page}`, () => {
+      cy.visit(page);
+      filters.forEach(({ id, url_key, test_val }) => {
+        cy.get(id).type(test_val);
+        cy.url().contains(`${url_key}=${test_val}`);
+      });
+    }),
+  );
+});

--- a/src/analytics/components.rs
+++ b/src/analytics/components.rs
@@ -14,7 +14,9 @@ pub fn AnalayticsFilters() -> impl IntoView {
     view! {
         <div class="w-full flex justify-start items-center p-2 pl-8 md:p-8 md:py-2">
             <div class="flex justify-start items-baseline mr-2 md:mr-4">
-                <label for="block-limit" class="mr-2">"Block limit:"</label>
+                <label for="block-limit" class="mr-2">
+                    "Block limit:"
+                </label>
                 <ControlledInput
                     id="block-limit"
                     input_type="number"
@@ -25,6 +27,7 @@ pub fn AnalayticsFilters() -> impl IntoView {
                         set_limit
                             .set(opt_str.map(|v_str| v_str.parse::<u64>().ok().unwrap_or_default()))
                     })
+
                     number_props=HashMap::from([
                         ("step".to_string(), "1000".to_string()),
                         ("min".to_string(), "1000".to_string()),
@@ -40,7 +43,6 @@ pub fn AnalayticsFilters() -> impl IntoView {
 
 #[component]
 pub fn SnarkFees() -> impl IntoView {
-    let default_block_limit = 1000;
     let (limit_sig, _) = create_query_signal::<u64>("limit");
     let resource = create_resource(
         move || limit_sig.get(),
@@ -78,11 +80,7 @@ pub fn SnarkFees() -> impl IntoView {
                     table_columns
                     data_sig
                     is_loading=resource.loading()
-                    section_heading=format!(
-                        "SNARK Fees in latest {} blocks",
-                        limit_sig.get().unwrap_or(default_block_limit),
-                    )
-
+                    section_heading="SNARK Fees Overview"
                     controls=|| ().into_view()
                 />
             }

--- a/src/analytics/components.rs
+++ b/src/analytics/components.rs
@@ -6,13 +6,42 @@ use crate::common::{
 use leptos::*;
 use leptos_router::create_query_signal;
 use std::collections::HashMap;
-// #[component]
-// pub fn AnalayticsFilters() -> impl IntoView {}
+
+#[component]
+pub fn AnalayticsFilters() -> impl IntoView {
+    let (limit_sig, set_limit) = create_query_signal::<u64>("limit");
+
+    view! {
+        <div class="w-full flex justify-start items-center p-2 pl-8 md:p-8 md:py-2">
+            <div class="flex justify-start items-baseline mr-2 md:mr-4">
+                <label for="block-limit" class="mr-2">"Block limit:"</label>
+                <ControlledInput
+                    id="block-limit"
+                    input_type="number"
+                    name="block-limit"
+                    disabled_sig=Signal::from(|| false)
+                    value=limit_sig.get().map(|s| s.to_string()).unwrap_or_default()
+                    setter_sig=SignalSetter::map(move |opt_str: Option<String>| {
+                        set_limit
+                            .set(opt_str.map(|v_str| v_str.parse::<u64>().ok().unwrap_or_default()))
+                    })
+                    number_props=HashMap::from([
+                        ("step".to_string(), "1000".to_string()),
+                        ("min".to_string(), "1000".to_string()),
+                        ("max".to_string(), "5000".to_string()),
+                    ])
+                />
+
+            </div>
+
+        </div>
+    }
+}
 
 #[component]
 pub fn SnarkFees() -> impl IntoView {
     let default_block_limit = 1000;
-    let (limit_sig, set_limit) = create_query_signal::<u64>("limit");
+    let (limit_sig, _) = create_query_signal::<u64>("limit");
     let resource = create_resource(
         move || limit_sig.get(),
         move |limit| async move { load_snark_fees(limit).await },
@@ -54,30 +83,7 @@ pub fn SnarkFees() -> impl IntoView {
                         limit_sig.get().unwrap_or(default_block_limit),
                     )
 
-                    controls=move || {
-                        view! {
-                            <ControlledInput
-                                id="block-selection"
-                                input_type="number"
-                                name="block-selection"
-                                disabled_sig=resource.loading()
-                                value=limit_sig.get().map(|s| s.to_string()).unwrap_or_default()
-                                setter_sig=SignalSetter::map(move |opt_str: Option<String>| {
-                                    set_limit
-                                        .set(
-                                            opt_str
-                                                .map(|v_str| v_str.parse::<u64>().ok().unwrap_or_default()),
-                                        )
-                                })
-
-                                number_props=HashMap::from([
-                                    ("step".to_string(), "1000".to_string()),
-                                    ("min".to_string(), "1000".to_string()),
-                                    ("max".to_string(), "5000".to_string()),
-                                ])
-                            />
-                        }
-                    }
+                    controls=|| ().into_view()
                 />
             }
         }

--- a/src/analytics/components.rs
+++ b/src/analytics/components.rs
@@ -5,6 +5,9 @@ use crate::common::{
 };
 use leptos::*;
 use leptos_router::create_query_signal;
+use std::collections::HashMap;
+// #[component]
+// pub fn AnalayticsFilters() -> impl IntoView {}
 
 #[component]
 pub fn SnarkFees() -> impl IntoView {
@@ -23,12 +26,6 @@ pub fn SnarkFees() -> impl IntoView {
                 .and_then(|res| res.ok())
                 .map(|data| SnarkStatsContainer::from(data.data.blocks)),
         ));
-    });
-
-    create_effect(move |_| {
-        if limit_sig.get().is_none() {
-            set_limit.set(Some(default_block_limit));
-        }
     });
 
     {
@@ -72,6 +69,12 @@ pub fn SnarkFees() -> impl IntoView {
                                                 .map(|v_str| v_str.parse::<u64>().ok().unwrap_or_default()),
                                         )
                                 })
+
+                                number_props=HashMap::from([
+                                    ("step".to_string(), "1000".to_string()),
+                                    ("min".to_string(), "1000".to_string()),
+                                    ("max".to_string(), "5000".to_string()),
+                                ])
                             />
                         }
                     }

--- a/src/analytics/page.rs
+++ b/src/analytics/page.rs
@@ -2,6 +2,7 @@ use super::{components::*, functions::*};
 use crate::common::{components::*, functions::*, models::*};
 use leptos::*;
 use leptos_meta::*;
+use leptos_router::create_query_signal;
 
 #[component]
 pub fn BlocksAnalyticsPage() -> impl IntoView {
@@ -91,6 +92,7 @@ pub fn BlocksAnalyticsPage() -> impl IntoView {
 
 #[component]
 pub fn SnarksAnalyticsPage() -> impl IntoView {
+    let (limit_sig, _) = create_query_signal::<u64>("limit");
     view! {
         <Title text="Analytics | SNARKs"/>
         <PageContainer>
@@ -100,13 +102,21 @@ pub fn SnarksAnalyticsPage() -> impl IntoView {
             </AppSection>
             <AppSection>
                 <AnalyticsLayout>
-                    <AnalyticsXLContainer>
-                        <div id="avg-snark-fee" class="w-full h-96"></div>
-                        <script
-                            src="/scripts/analytics/avg-snark-fee-per-block.js"
-                            defer=true
-                        ></script>
-                    </AnalyticsXLContainer>
+                    {move || {
+                        limit_sig.get();
+                        view! {
+                            // redraw
+
+                            <AnalyticsXLContainer>
+                                <div id="avg-snark-fee" class="w-full h-96"></div>
+                                <script
+                                    src="/scripts/analytics/avg-snark-fee-per-block.js"
+                                    defer=true
+                                ></script>
+                            </AnalyticsXLContainer>
+                        }
+                    }}
+
                 </AnalyticsLayout>
             </AppSection>
             <SnarkFees/>

--- a/src/analytics/page.rs
+++ b/src/analytics/page.rs
@@ -95,6 +95,10 @@ pub fn SnarksAnalyticsPage() -> impl IntoView {
         <Title text="Analytics | SNARKs"/>
         <PageContainer>
             <AppSection>
+                <AppHeading heading="Filters"/>
+                <AnalayticsFilters/>
+            </AppSection>
+            <AppSection>
                 <AnalyticsLayout>
                     <AnalyticsXLContainer>
                         <div id="avg-snark-fee" class="w-full h-96"></div>

--- a/src/common/components.rs
+++ b/src/common/components.rs
@@ -1,12 +1,62 @@
 use super::models::*;
 use crate::{
-    common::{constants::LINK_HOVER_STATE, functions::*},
+    common::{constants::*, functions::*},
     icons::*,
 };
 use leptos::{html::Div, *};
 use leptos_meta::Script;
-use leptos_router::*;
+use leptos_router::{create_query_signal, *};
+use leptos_use::{use_debounce_fn_with_options, DebounceOptions};
 use web_sys::{window, Event, MouseEvent};
+
+#[component]
+pub fn ControlledInput(
+    #[prop(into, default = "controlled-input-id".to_string())] id: String,
+    #[prop(into, default = "controlled-input-name".to_string())] name: String,
+    #[prop(into)] input_type: String,
+    #[prop(into)] disabled_sig: Signal<bool>,
+    #[prop(into)] value: String,
+    #[prop(into)] setter_sig: SignalSetter<Option<String>>,
+    #[prop(optional)] input_class: Option<String>,
+) -> impl IntoView {
+    let unwrapped_input_class = input_class.unwrap_or(DEFAULT_INPUT_STYLES.to_string());
+    let input_element: NodeRef<html::Input> = create_node_ref();
+    let (handle_input_sig, _) = create_signal(use_debounce_fn_with_options(
+        move || {
+            let v = input_element
+                .get()
+                .expect("<input/> should be mounted")
+                .value();
+            setter_sig.set(Some(v));
+        },
+        DEFAULT_USER_INPUT_DEBOUNCE_INTERNVAL,
+        DebounceOptions::default(),
+    ));
+
+    view! {
+        <input
+            id=id
+            type=input_type
+            on:keypress=move |ev| {
+                ev.prevent_default();
+            }
+
+            on:input=move |_| {
+                let handle = handle_input_sig.get_untracked();
+                handle();
+            }
+
+            disabled=move || disabled_sig.get()
+            name=name
+            value=value
+            step=1000
+            max=5000
+            min=1000
+            class=unwrapped_input_class
+            node_ref=input_element
+        />
+    }
+}
 
 #[component]
 pub fn SummaryItem(

--- a/src/common/components.rs
+++ b/src/common/components.rs
@@ -7,6 +7,7 @@ use leptos::{html::Div, *};
 use leptos_meta::Script;
 use leptos_router::{create_query_signal, *};
 use leptos_use::{use_debounce_fn_with_options, DebounceOptions};
+use std::collections::HashMap;
 use web_sys::{window, Event, MouseEvent};
 
 #[component]
@@ -18,6 +19,7 @@ pub fn ControlledInput(
     #[prop(into)] value: String,
     #[prop(into)] setter_sig: SignalSetter<Option<String>>,
     #[prop(optional)] input_class: Option<String>,
+    #[prop(optional)] number_props: Option<HashMap<String, String>>,
 ) -> impl IntoView {
     let unwrapped_input_class = input_class.unwrap_or(DEFAULT_INPUT_STYLES.to_string());
     let input_element: NodeRef<html::Input> = create_node_ref();
@@ -49,9 +51,12 @@ pub fn ControlledInput(
             disabled=move || disabled_sig.get()
             name=name
             value=value
-            step=1000
-            max=5000
-            min=1000
+            step=number_props
+                .clone()
+                .and_then(|props| props.get("step").cloned())
+                .unwrap_or_default()
+            max=number_props.clone().and_then(|props| props.get("max").cloned()).unwrap_or_default()
+            min=number_props.and_then(|props| props.get("min").cloned()).unwrap_or_default()
             class=unwrapped_input_class
             node_ref=input_element
         />

--- a/src/common/constants.rs
+++ b/src/common/constants.rs
@@ -21,3 +21,4 @@ pub const LHS_MAX_DIGIT_PADDING: usize = 13;
 pub const LHS_MAX_SPACE_FEES: usize = 2;
 pub const TXN_STATUS_APPLIED: &str = "Applied";
 pub const TXN_STATUS_FAILED: &str = "Failed";
+pub const DEFAULT_INPUT_STYLES: &str = "block h-8 text-base text-sm font-normal font-mono p-2 text-right border rounded-sm border-slate-400 focus:border-granola-orange";

--- a/src/common/constants.rs
+++ b/src/common/constants.rs
@@ -21,4 +21,4 @@ pub const LHS_MAX_DIGIT_PADDING: usize = 13;
 pub const LHS_MAX_SPACE_FEES: usize = 2;
 pub const TXN_STATUS_APPLIED: &str = "Applied";
 pub const TXN_STATUS_FAILED: &str = "Failed";
-pub const DEFAULT_INPUT_STYLES: &str = "block h-8 text-base text-sm font-normal font-mono p-2 text-right border rounded-sm border-slate-400 focus:border-granola-orange";
+pub const DEFAULT_INPUT_STYLES: &str = "block h-6 text-base text-sm font-normal font-mono p-2 text-right border rounded-sm border-slate-400 focus:border-granola-orange";

--- a/src/scripts/analytics/avg-snark-fee-per-block.js
+++ b/src/scripts/analytics/avg-snark-fee-per-block.js
@@ -1,6 +1,8 @@
 setTimeout(async () => {
   const currentBlockHeight = 359604;
-  const blockLimit = 1000;
+  const queryString = window.location.search;
+  const urlParams = new URLSearchParams(queryString);
+  const blockLimit = urlParams.get("limit") || 1000;
   const blockOffset = currentBlockHeight - blockLimit;
 
   let chartDom = document.getElementById("avg-snark-fee");
@@ -73,7 +75,7 @@ setTimeout(async () => {
       position: "top",
     },
     title: {
-      text: `Fees by block with averages (last ${blockLimit} blocks)`,
+      text: `Fees by block with averages`,
       left: "center",
     },
     xAxis: {


### PR DESCRIPTION
### Linked Issue
Relates to (but does not close): https://github.com/Granola-Team/mina-indexer/issues/1506

### Motivation
We need to remove filtering embedded in graphs and create a URL connected component that support filtering over the entire page. URL connected inputs within this new component is a step towards that end.