### PR TITLE
Fix runtime panics in WASM bundle triggered from the account activity page

### DIFF
--- a/cypress/e2e/tab-number-bubble/tabs.cy.js
+++ b/cypress/e2e/tab-number-bubble/tabs.cy.js
@@ -54,7 +54,7 @@ suite(["@tier2"], "number bubble in tab", () => {
 
       cy.contains("a.tab", tab).find(".number-bubble").as("bubble");
       cy.wait(100);
-      cy.get("@bubble").should("not.equal", 0);
+      cy.get("@bubble").should("not.equal", "0");
 
       cy.get("@bubble")
         .invoke("text")

--- a/src/account_activity/components.rs
+++ b/src/account_activity/components.rs
@@ -181,7 +181,7 @@ pub fn AccountInternalCommandsSection(
 #[component]
 pub fn AccountDelegationsSection(
     delegations_sig: ReadSignal<Option<Vec<Option<AccountActivityQueryDelegatorExt>>>>,
-    delegator_count: Option<i64>,
+    delegator_count: Option<usize>,
     is_loading: Signal<bool>,
 ) -> impl IntoView {
     let table_columns = vec![

--- a/src/account_activity/models.rs
+++ b/src/account_activity/models.rs
@@ -10,6 +10,9 @@ use heck::ToTitleCase;
 use leptos_router::Params;
 use serde::{Deserialize, Serialize};
 
+#[derive(Copy, Clone)]
+pub struct DelegateCount(pub usize);
+
 #[derive(Params, PartialEq)]
 pub struct URLParams {
     pub id: Option<String>,

--- a/src/account_activity/page.rs
+++ b/src/account_activity/page.rs
@@ -323,6 +323,7 @@ pub fn AccountSpotlightTabbedPage() -> impl IntoView {
             blocks.get();
             account.get();
             delegators.get();
+            delegators_count.get();
             view! { <AccountSpotlightTabs /> }
         }}
         <AccountSpotlightPage />

--- a/src/account_activity/page.rs
+++ b/src/account_activity/page.rs
@@ -239,25 +239,18 @@ pub fn AccountSpotlightTabbedPage() -> impl IntoView {
                 .collect();
             transactions.sort_by(|a, b| {
                 match (
-                        <std::option::Option<
-                            AccountActivityQueryDirectionalTransactions,
-                        > as Clone>::clone(a)
-                            .unwrap()
-                            .date_time,
-                        <std::option::Option<
-                            AccountActivityQueryDirectionalTransactions,
-                        > as Clone>::clone(b)
-                            .unwrap()
-                            .date_time,
-                    ) {
-                        (Some(date_time_a), Some(date_time_b)) => {
-                            date_time_b.cmp(&date_time_a)
-                        }
-                        (Some(_), None) => std::cmp::Ordering::Greater,
-                        (None, Some(_)) => std::cmp::Ordering::Less,
-                        (None, None) => std::cmp::Ordering::Equal,
-                    }
+                    a.clone()
+                        .and_then(|x: AccountActivityQueryDirectionalTransactions| x.date_time),
+                    b.clone()
+                        .and_then(|x: AccountActivityQueryDirectionalTransactions| x.date_time),
+                ) {
+                    (Some(date_time_a), Some(date_time_b)) => date_time_b.cmp(&date_time_a),
+                    (Some(_), None) => std::cmp::Ordering::Greater,
+                    (None, Some(_)) => std::cmp::Ordering::Less,
+                    (None, None) => std::cmp::Ordering::Equal,
+                }
             });
+
             let end_index = res.snarks.len().min(50);
             set_transactions.set(Some(transactions));
             set_snarks.set(Some(res.snarks[..end_index].to_vec()));

--- a/src/account_activity/page.rs
+++ b/src/account_activity/page.rs
@@ -1,7 +1,7 @@
-use super::models::DelegateCount;
-use super::{functions::*, models::*};
-use crate::account_activity::graphql::account_activity_query::AccountActivityQueryIncomingTransactions;
-use crate::account_activity::graphql::account_activity_query::AccountActivityQueryOutgoingTransactions;
+use super::{
+    functions::*,
+    models::{DelegateCount, *},
+};
 use crate::{
     account_activity::{
         components::{
@@ -10,7 +10,8 @@ use crate::{
         },
         graphql::account_activity_query::{
             AccountActivityQueryAccounts, AccountActivityQueryBlocks,
-            AccountActivityQueryFeetransfers, AccountActivityQuerySnarks,
+            AccountActivityQueryFeetransfers, AccountActivityQueryIncomingTransactions,
+            AccountActivityQueryOutgoingTransactions, AccountActivityQuerySnarks,
         },
         models::AccountActivityQueryDirectionalTransactions,
     },
@@ -315,16 +316,14 @@ pub fn AccountSpotlightTabbedPage() -> impl IntoView {
     provide_context(delegators_count);
 
     view! {
-        { move || {
+        {move || {
             transactions.get();
             internal_transactions.get();
             snarks.get();
             blocks.get();
             account.get();
             delegators.get();
-            view! {
-                <AccountSpotlightTabs />
-            }
+            view! { <AccountSpotlightTabs /> }
         }}
         <AccountSpotlightPage />
     }
@@ -396,7 +395,5 @@ pub fn AccountSpotlightTabs() -> impl IntoView {
         },
     ];
 
-    view! {
-        <TabbedPage tabs exclude_outlet=true />
-    }
+    view! { <TabbedPage tabs exclude_outlet=true /> }
 }


### PR DESCRIPTION
## Describe your changes
Back navigation was being hampered due to panics within the WASM runtime. This is a fix.

## Issue ticket number and link
#1027 

## Checklist for contributors
- [x] I have performed a self-review of my code
- [x] I have run tier2 tests locally, and they pass

## Checklist for reviewers
- [ ] I have run tier2 tests locally, and they pass
