### PR TITLE
Prevent accidentally publishing an incorrectly compiled WASM bundle

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -95,9 +95,13 @@ test-e2e-local: pnpm-install deploy-mina-indexer
     --first-cmd="trunk serve --no-autoreload --port={{trunk_port}}" \
     --second-cmd="pnpm exec cypress open"
 
-# Publish application
-publish: clean pnpm-install
+pre-publish:
+  @echo "--- Validating environment variables for publishing"
   ruby ops/validate-env.rb GRAPHQL_URL REST_URL
+  ruby -e '["GRAPHQL_URL", "REST_URL"].each { |var| exit 1 if ENV[var].include?("localhost") || ENV[var].include?("127.0.0.1") }; exit 0'
+
+# Publish application
+publish: pre-publish clean pnpm-install
   @echo "--- Publishing"
   trunk build --release --filehash true
   @echo "Publishing version {{VERSION}}"


### PR DESCRIPTION
## Describe your changes
Environment variables such as the GRAPHQL_URL and REST_URL are integrated into the source code at compile time. It is easy to publish a bundle to prod without first cleaning `just clean` and changing your environment before rebuilding and publishing `just publish`. This introduces a quick environment variable check just before the `clean` phase in the `publish` step to ensure anything with either `localhost` or `127.0.0.1` are not present in those two variables.

## Issue ticket number and link
#1033 

## Checklist for contributors
- [x] I have performed a self-review of my code
- [x] I have run tier2 tests locally, and they pass

## Checklist for reviewers
- [ ] I have run tier2 tests locally, and they pass
