### PR TITLE
feat: format currency with commas and strip unnecessary decimal 0s

### DIFF
--- a/src/account_activity/table_traits.rs
+++ b/src/account_activity/table_traits.rs
@@ -126,7 +126,7 @@ impl TableData for Vec<Option<AccountActivityQuerySnarks>> {
                         snark.get_date_time(),
                     ),
                     convert_to_span(snark.get_prover()),
-                    decorate_with_mina_tag(snark.get_fee()),
+                    decorate_with_mina_tag(strip_decimal_if_zero(snark.get_fee())),
                 ],
                 None => vec![],
             })
@@ -214,7 +214,7 @@ impl TableData for Vec<Option<AccountActivityQueryBlocks>> {
                         block.get_date_time(),
                     ),
                     convert_to_span(block.get_creator_account()),
-                    decorate_with_mina_tag(block.get_coinbase()),
+                    decorate_with_mina_tag(strip_decimal_if_zero(block.get_coinbase())),
                     convert_to_pill(block.get_transaction_count(), ColorVariant::Blue),
                     convert_to_pill(block.get_snark_job_count(), ColorVariant::Blue),
                     convert_to_link(
@@ -331,7 +331,7 @@ impl TableData for Vec<Option<AccountActivityQueryFeetransfers>> {
                         internal_command.get_state_hash(),
                         format!("/blocks/{}", internal_command.get_state_hash()),
                     ),
-                    decorate_with_mina_tag(internal_command.get_fee()),
+                    decorate_with_mina_tag(strip_decimal_if_zero(internal_command.get_fee())),
                     convert_to_pill(internal_command.get_type(), ColorVariant::Grey),
                     convert_to_title(
                         print_time_since(&internal_command.get_block_datetime()),

--- a/src/blocks/components.rs
+++ b/src/blocks/components.rs
@@ -222,21 +222,27 @@ pub fn BlockAnalytics(block: BlocksQueryBlocks) -> impl IntoView {
                 <AnalyticsSmContainer>
                     <AnalyticsSimpleInfo
                         label=convert_to_span("Total User Amounts Transferred".into())
-                        value=decorate_with_mina_tag(nanomina_to_mina(user_command_amount_total()))
+                        value=decorate_with_mina_tag(
+                            strip_decimal_if_zero(nanomina_to_mina(user_command_amount_total())),
+                        )
                     />
 
                 </AnalyticsSmContainer>
                 <AnalyticsSmContainer>
                     <AnalyticsSimpleInfo
                         label=convert_to_span("Total Internal Fees Transferred".into())
-                        value=decorate_with_mina_tag(get_transaction_fees(&block_sig.get()))
+                        value=decorate_with_mina_tag(
+                            strip_decimal_if_zero(get_transaction_fees(&block_sig.get())),
+                        )
                     />
                 </AnalyticsSmContainer>
                 <AnalyticsSmContainer>
                     <AnalyticsSimpleInfo
                         label=convert_to_span("Total SNARK Fees".into())
                         value=wrap_in_pill(
-                            decorate_with_mina_tag(get_snark_fees(&block_sig.get())),
+                            decorate_with_mina_tag(
+                                strip_decimal_if_zero(get_snark_fees(&block_sig.get())),
+                            ),
                             ColorVariant::Blue,
                         )
                     />
@@ -429,7 +435,9 @@ pub fn BlockSpotlight(block: BlocksQueryBlocks) -> impl IntoView {
         },
         SpotlightEntry {
             label: "Coinbase".to_string(),
-            any_el: Some(decorate_with_mina_tag(get_coinbase(&block))),
+            any_el: Some(decorate_with_mina_tag(strip_decimal_if_zero(get_coinbase(
+                &block,
+            )))),
             ..Default::default()
         },
         SpotlightEntry {
@@ -445,7 +453,9 @@ pub fn BlockSpotlight(block: BlocksQueryBlocks) -> impl IntoView {
         },
         SpotlightEntry {
             label: "SNARK Fees".to_string(),
-            any_el: Some(decorate_with_mina_tag(get_snark_fees(&block))),
+            any_el: Some(decorate_with_mina_tag(strip_decimal_if_zero(
+                get_snark_fees(&block),
+            ))),
             ..Default::default()
         },
         SpotlightEntry {
@@ -465,7 +475,9 @@ pub fn BlockSpotlight(block: BlocksQueryBlocks) -> impl IntoView {
         },
         SpotlightEntry {
             label: "Transaction Fees".to_string(),
-            any_el: Some(decorate_with_mina_tag(get_transaction_fees(&block))),
+            any_el: Some(decorate_with_mina_tag(strip_decimal_if_zero(
+                get_transaction_fees(&block),
+            ))),
             ..Default::default()
         },
         SpotlightEntry {
@@ -478,7 +490,9 @@ pub fn BlockSpotlight(block: BlocksQueryBlocks) -> impl IntoView {
         },
         SpotlightEntry {
             label: "Total MINA".to_string(),
-            any_el: Some(decorate_with_mina_tag(get_total_currency(&block))),
+            any_el: Some(decorate_with_mina_tag(strip_decimal_if_zero(
+                get_total_currency(&block),
+            ))),
             ..Default::default()
         },
         SpotlightEntry {

--- a/src/blocks/table_traits.rs
+++ b/src/blocks/table_traits.rs
@@ -63,7 +63,7 @@ impl TableData for Vec<Option<BlocksQueryBlocks>> {
                         get_creator_account(block),
                         format!("/addresses/accounts/{}", get_creator_account(block)),
                     ),
-                    decorate_with_mina_tag(get_coinbase(block)),
+                    decorate_with_mina_tag(strip_decimal_if_zero(get_coinbase(block))),
                     convert_to_pill(
                         get_transaction_count(block).map_or_else(String::new, |o| o.to_string()),
                         ColorVariant::Blue,
@@ -134,9 +134,9 @@ impl TableData for Vec<Option<BlocksQueryBlocksTransactionsUserCommandsExt>> {
                         format!("/addresses/accounts/{}", user_command.get_to()),
                     ),
                     convert_to_pill(format_number(user_command.get_nonce()), ColorVariant::Grey),
-                    decorate_with_mina_tag(nanomina_to_mina(
+                    decorate_with_mina_tag(strip_decimal_if_zero(nanomina_to_mina(
                         user_command.get_fee().parse::<u64>().ok().unwrap_or(0),
-                    )),
+                    ))),
                     decorate_with_mina_tag(nanomina_to_mina(
                         user_command.get_amount().parse::<u64>().ok().unwrap_or(0),
                     )),
@@ -230,7 +230,7 @@ impl TableData for Vec<Option<BlocksQueryBlocksSnarkJobs>> {
                         get_snark_prover(snark),
                         format!("/addresses/accounts/{}", get_snark_prover(snark)),
                     ),
-                    decorate_with_mina_tag(get_snark_fee(snark)),
+                    decorate_with_mina_tag(strip_decimal_if_zero(get_snark_fee(snark))),
                 ],
                 None => vec![],
             })
@@ -247,7 +247,7 @@ impl TableData for Vec<Option<BlocksQueryBlocksTransactionsFeeTransfer>> {
                         fee_transfer.get_receipient(),
                         format!("/addresses/accounts/{}", fee_transfer.get_receipient()),
                     ),
-                    decorate_with_mina_tag(fee_transfer.get_fee()),
+                    decorate_with_mina_tag(strip_decimal_if_zero(fee_transfer.get_fee())),
                     convert_to_pill(fee_transfer.get_type(), ColorVariant::Grey),
                 ],
                 None => vec![],

--- a/src/internal_commands/table_traits.rs
+++ b/src/internal_commands/table_traits.rs
@@ -30,7 +30,7 @@ impl TableData for Vec<Option<InternalCommandsQueryFeetransfers>> {
                         internal_command.get_receipient(),
                         format!("/addresses/accounts/{}", internal_command.get_receipient()),
                     ),
-                    decorate_with_mina_tag(internal_command.get_fee()),
+                    decorate_with_mina_tag(strip_decimal_if_zero(internal_command.get_fee())),
                     convert_to_pill(internal_command.get_type(), ColorVariant::Grey),
                     convert_to_title(
                         print_time_since(&internal_command.get_block_datetime()),

--- a/src/user_commands/page.rs
+++ b/src/user_commands/page.rs
@@ -160,7 +160,7 @@ pub fn CommandSpotlightPage() -> impl IntoView {
                                     label: "Amount".to_string(),
                                     any_el: {
                                         let amount_el = decorate_with_mina_tag(
-                                            transaction.get_amount(),
+                                            strip_decimal_if_zero(transaction.get_amount()),
                                         );
                                         Some(
                                             if transaction.get_kind() == STAKE_DELEGATION_TYPE {
@@ -181,7 +181,11 @@ pub fn CommandSpotlightPage() -> impl IntoView {
                                 },
                                 SpotlightEntry {
                                     label: "Fee".to_string(),
-                                    any_el: Some(decorate_with_mina_tag(transaction.get_fee())),
+                                    any_el: Some(
+                                        decorate_with_mina_tag(
+                                            strip_decimal_if_zero(transaction.get_fee()),
+                                        ),
+                                    ),
                                     ..Default::default()
                                 },
                                 SpotlightEntry {

--- a/src/zk_apps/page.rs
+++ b/src/zk_apps/page.rs
@@ -46,7 +46,11 @@ pub fn ZkAppSpotlight() -> impl IntoView {
                 spotlight_items=vec![
                     SpotlightEntry {
                         label: String::from("Balance"),
-                        any_el: Some(decorate_with_mina_tag("1324.593847562".to_string())),
+                        any_el: Some(
+                            decorate_with_mina_tag(
+                                strip_decimal_if_zero("1324.593847562".to_string()),
+                            ),
+                        ),
                         ..Default::default()
                     },
                     SpotlightEntry {

--- a/src/zk_apps/table_trait.rs
+++ b/src/zk_apps/table_trait.rs
@@ -8,7 +8,7 @@ impl TableData for Vec<Option<ZkAppData>> {
             .map(|opt_app| match opt_app {
                 Some(zk_app) => vec![
                     convert_to_link(zk_app.validator_pk.to_string(), "#".to_string()),
-                    decorate_with_mina_tag(zk_app.balance.to_string()),
+                    decorate_with_mina_tag(strip_decimal_if_zero(zk_app.balance.to_string())),
                     convert_to_pill(format_number(zk_app.nonce.to_string()), ColorVariant::Blue),
                     convert_to_link(zk_app.delegate.to_string(), "#".to_string()),
                 ],
@@ -37,7 +37,7 @@ impl TableData for Vec<Option<ZkAppTransactionData>> {
                             .collect::<Vec<_>>(),
                     )
                     .attr("class", "block"),
-                    decorate_with_mina_tag(txn.fee.to_string()),
+                    decorate_with_mina_tag(strip_decimal_if_zero(txn.fee.to_string())),
                 ],
                 None => vec![],
             })


### PR DESCRIPTION
Ensure commas where they belong and remove any trailing 0s after the decimal.