### PR TITLE
chore: 0 -> "Free"

### DIFF
--- a/src/common/functions.rs
+++ b/src/common/functions.rs
@@ -437,7 +437,7 @@ pub fn decorate_with_currency_tag(
                 }
                     .into_view()
             } else {
-                view! { {data} }.into_view()
+                view! { "Free" }.into_view()
             }}
 
         </span>


### PR DESCRIPTION
Only fees should ever be 0.

Fixes Granola-Team/mina-block-explorer#1118
